### PR TITLE
fix common query

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -91,13 +91,13 @@ class WikipediaSkill(CommonQuerySkill):
 
     # common query
     def CQS_match_query_phrase(self, utt):
-        summary = self.ask_the_wiki(utt)
+        title, summary = self.ask_the_wiki(utt)
         if summary:
             self.idx += 1  # spoken by common query
             return (utt, CQSMatchLevel.GENERAL, summary,
                     {'query': utt,
                      'image': self.image,
-                     'title':data.get("title") or phrase,
+                     'title': title,
                      'answer': summary})
 
     def CQS_action(self, phrase, data):
@@ -113,7 +113,8 @@ class WikipediaSkill(CommonQuerySkill):
         self.results = self.wiki.long_answer(query, lang=self.lang)
         self.image = self.wiki.get_image(query)
         if self.results:
-            return self.results[0]["summary"]
+            title = self.results[0].get("title") or query
+            return title, self.results[0]["summary"]
 
     def display_wiki_entry(self, title="Wikipedia", image=None):
         if not can_use_gui(self.bus):

--- a/__init__.py
+++ b/__init__.py
@@ -97,12 +97,13 @@ class WikipediaSkill(CommonQuerySkill):
             return (utt, CQSMatchLevel.GENERAL, summary,
                     {'query': utt,
                      'image': self.image,
+                     'title':data.get("title") or phrase,
                      'answer': summary})
 
     def CQS_action(self, phrase, data):
         """ If selected show gui """
         self.display_wiki_entry()
-        self.set_context("WikiKnows", data["title"])
+        self.set_context("WikiKnows", data.get("title") or phrase)
 
     # wikipedia
     def ask_the_wiki(self, query):

--- a/__init__.py
+++ b/__init__.py
@@ -63,7 +63,7 @@ class WikipediaSkill(CommonQuerySkill):
         self.current_title = query = message.data["query"]
         self.speak_dialog("searching", {"query": query})
         self.image = None
-        summary = self.ask_the_wiki(query)
+        title, summary = self.ask_the_wiki(query)
         if summary:
             self.speak_result()
         else:
@@ -115,6 +115,7 @@ class WikipediaSkill(CommonQuerySkill):
         if self.results:
             title = self.results[0].get("title") or query
             return title, self.results[0]["summary"]
+        return None, None
 
     def display_wiki_entry(self, title="Wikipedia", image=None):
         if not can_use_gui(self.bus):


### PR DESCRIPTION
```
2023-03-29 18:30:02.755 - skills - mycroft.skills.intent_service:_normalize_all_utterances:61 - DEBUG - Utterances: [('what do you do',)]
2023-03-29 18:30:02.816 - skills - mycroft.skills.intent_services.padatious_service:_match_level:87 - DEBUG - Padatious Matching confidence > 0.95
2023-03-29 18:30:02.817 - skills - mycroft.skills.intent_services.commonqa_service:handle_question:119 - INFO - Searching for what do you do
2023-03-29 18:30:04.586 - skills - mycroft.skills.intent_services.commonqa_service:handle_query_response:153 - INFO - Answer from skill-ovos-wikipedia.openvoiceos
2023-03-29 18:30:04.586 - skills - mycroft.skills.intent_services.commonqa_service:_query_timeout:173 - INFO - Timeout occurred check responses
2023-03-29 18:30:04.587 - skills - mycroft.skills.intent_services.commonqa_service:_query_timeout:198 - INFO - Handling with: skill-ovos-wikipedia.openvoiceos
2023-03-29 18:30:07.632 - skills - ovos_workshop.skills.base:_on_event_error:1230 - ERROR - 'title'
Traceback (most recent call last):
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_utils/messagebus.py", line 351, in wrapper
    handler(message)
  File "/home/ovos/.venv/lib/python3.11/site-packages/mycroft/skills/common_query_skill.py", line 185, in __handle_query_action
    self.CQS_action(phrase, data)
  File "/home/ovos/.local/share/mycroft/skills/skill-ovos-wikipedia.openvoiceos/__init__.py", line 105, in CQS_action
    self.set_context("WikiKnows", data["title"])
                                  ~~~~^^^^^^^^^
KeyError: 'title'
```