### PR TITLE
rm non specific intent

### DIFF
--- a/locale/en-us/wiki.intent
+++ b/locale/en-us/wiki.intent
@@ -1,4 +1,3 @@
 (wiki|wikipedia) {query}
-tell (us|me) about {query}
 what does (wiki|wikipedia) say about {query}
 (search|check) (wiki|wikipedia) for {query}


### PR DESCRIPTION
only sentences explicitly asking for wikipedia should be considered


"tell (us|me) about {query}" belongs in CommonQA to allow it to select the best skill

fixes https://github.com/OpenVoiceOS/skill-ovos-wikipedia/issues/24