### PR TITLE
Add image parsing to results with unit test

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -246,10 +246,11 @@ class WikipediaSkill(CommonQuerySkill):
         """If selected show gui"""
 
         sess = SessionManager.get()
-        if sess in self.session_results:
+        if sess.session_id in self.session_results:
             self.display_wiki_entry()
         else:
-            LOG.error(f"Session not found in results: {sess}")
+            LOG.error(f"{sess.session_id} not in "
+                      f"{list(self.session_results.keys())}")
 
         self.set_context("WikiKnows", data.get("title") or phrase)
 
@@ -289,7 +290,7 @@ class WikipediaSkill(CommonQuerySkill):
 
     def speak_result(self, sess: Session):
 
-        if sess in self.session_results:
+        if sess.session_id in self.session_results:
             results = self.session_results[sess.session_id]["results"]
             idx = self.session_results[sess.session_id]["idx"]
             title = self.session_results[sess.session_id].get("title") or \

--- a/__init__.py
+++ b/__init__.py
@@ -248,6 +248,8 @@ class WikipediaSkill(CommonQuerySkill):
         sess = SessionManager.get()
         if sess in self.session_results:
             self.display_wiki_entry()
+        else:
+            LOG.error(f"Session not found in results: {sess}")
 
         self.set_context("WikiKnows", data.get("title") or phrase)
 
@@ -272,13 +274,18 @@ class WikipediaSkill(CommonQuerySkill):
 
     def display_wiki_entry(self):
         if not can_use_gui(self.bus):
+            LOG.debug(f"GUI not enabled")
             return
         sess = SessionManager.get()
-        image = self.session_results[sess.session_id].get("image") or self.wiki.get_image(query)
+        image = self.session_results[sess.session_id].get("image") or \
+                self.wiki.get_image(self.session_results[sess.session_id]["query"])
         title = self.session_results[sess.session_id].get("title") or "Wikipedia"
         if image:
             self.session_results[sess.session_id]["image"] = image
-            self.gui.show_image(image, title=title, fill=None, override_idle=20, override_animations=True)
+            self.gui.show_image(image, title=title, fill=None,
+                                override_idle=20, override_animations=True)
+        else:
+            LOG.warning(f"No image in {self.session_results[sess.session_id]}")
 
     def speak_result(self, sess: Session):
 

--- a/__init__.py
+++ b/__init__.py
@@ -88,9 +88,11 @@ class WikipediaSolver(QuestionSolver):
 
             summary = r['query']['pages'][pid]['extract']
             img = None
-            if "pageimage" in r['query']['pages'][pid]:
-                i = f"https://{lang}.wikipedia.org/wiki/File:" + r['query']['pages'][pid]['pageimage']
-                # TODO - final image url
+            if "thumbnail" in r['query']['pages'][pid]:
+                thumbnail = r['query']['pages'][pid]['thumbnail']['source']
+                parts = thumbnail.split("/")[:-1]
+                img = '/'.join((part for part in parts if part != 'thumb'))
+                LOG.debug(f"Found image: {img}")
 
             summary = rm_parentheses(summary)  # normalize to make more speakable
 

--- a/__init__.py
+++ b/__init__.py
@@ -283,7 +283,7 @@ class WikipediaSkill(CommonQuerySkill):
         title = self.session_results[sess.session_id].get("title") or "Wikipedia"
         if image:
             self.session_results[sess.session_id]["image"] = image
-            self.gui.show_image(image, title=title, fill=None,
+            self.gui.show_image(image, title=title, fill='PreserveAspectFit',
                                 override_idle=20, override_animations=True)
         else:
             LOG.warning(f"No image in {self.session_results[sess.session_id]}")

--- a/__init__.py
+++ b/__init__.py
@@ -286,7 +286,7 @@ class WikipediaSkill(CommonQuerySkill):
             self.gui.show_image(image, title=title, fill='PreserveAspectFit',
                                 override_idle=20, override_animations=True)
         else:
-            LOG.warning(f"No image in {self.session_results[sess.session_id]}")
+            LOG.info(f"No image in {self.session_results[sess.session_id]}")
 
     def speak_result(self, sess: Session):
 

--- a/__init__.py
+++ b/__init__.py
@@ -104,6 +104,10 @@ class WikipediaSolver(QuestionSolver):
         data = self.get_data(query, context)
         return data.get("short_answer", "")
 
+    def get_image(self, query, context=None):
+        data = self.get_data(query, context)
+        return data.get("img", "")
+
     def get_expanded_answer(self, query, context=None):
         """
         return a list of ordered steps to expand the answer, eg, "tell me more"
@@ -262,6 +266,7 @@ class WikipediaSkill(CommonQuerySkill):
         if results:
             title = results[0].get("title") or \
                     self.session_results[sess.session_id]["query"]
+            self.session_results[sess.session_id]["image"] = results[0].get("img")
             return title, results[0]["summary"]
         return None, None
 

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 
+import requests
 from ovos_utils.messagebus import FakeBus
 from skill_ovos_wikipedia import WikipediaSkill
 from ovos_workshop.skills.common_query_skill import CommonQuerySkill
@@ -78,3 +79,16 @@ class TestSkill(unittest.TestCase):
                         f"{self.skill.skill_id}.deactivate"]
         for event in default_ovos:
             self.assertTrue(event in registered_events)
+
+    def test_solver_get_data(self):
+        solver = self.skill.wiki
+        test_queries = ("rocks", "paper", "scissors", "computers")
+        for query in test_queries:
+            data = solver.get_data(query)
+            self.assertIsInstance(data["title"], str)
+            self.assertIsInstance(data["short_answer"], str)
+            self.assertIsInstance(data["summary"], str)
+            self.assertIsInstance(data["img"], str)
+            image = requests.get(data["img"],
+                                 headers={"User-Agent": "ovos-skill-unit-test"})
+            self.assertTrue(image.ok, image)


### PR DESCRIPTION
Parses full-sized image URL from thumbnail URL. In testing this appears to always be valid
Closes #36
Includes fix for session lookup in `self.session_results`

Rebase on #38 to run tests